### PR TITLE
Add initial cross-platform transcriber project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: build
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Build distribution
+        run: |
+          python build.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos-app
+          path: dist/app
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -r requirements.txt
+      - name: Build exe
+        run: |
+          python build.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-exe
+          path: dist/transcriber

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.venv/
+build/
+dist/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# gijirock2
+# Speech Transcriber
+
+This project provides a cross-platform CLI/GUI tool for running speech recognition models hosted on Hugging Face.
+
+## Requirements
+- Python 3.10+
+- ffmpeg (bundled binaries provided)
+
+## Setup
+
+### Using `venv`
+```bash
+python3 -m venv .venv
+# macOS/Linux
+source .venv/bin/activate
+# Windows
+.venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+### Optional: install via Conda for `pyannote.audio`
+```bash
+conda create -n transcriber python=3.10
+conda activate transcriber
+pip install -r requirements.txt
+```
+
+Create a `.env` file with your HuggingFace token:
+```
+HF_TOKEN=your_token_here
+```
+
+## Usage
+
+### CLI
+```
+python main.py path/to/file.wav --model openai/whisper-small
+```
+
+### GUI
+```
+python gui.py
+```
+
+## Building executables
+Run the helper script which uses PyInstaller on Windows and directory packaging on macOS:
+```
+python build.py
+```
+
+## GitHub Actions
+The workflow `build.yml` builds the project on macOS and Windows and uploads the artifacts (`tar.gz` for macOS and `exe` for Windows).
+
+## Troubleshooting
+If `pyannote.audio` fails to install, ensure you are using a compatible Python version and that `torch` is installed. Using a Conda environment is recommended when installation errors occur.

--- a/app.spec
+++ b/app.spec
@@ -1,0 +1,30 @@
+# -*- mode: python -*-
+block_cipher = None
+
+a = Analysis(['main.py', 'gui.py'],
+             pathex=['.'],
+             binaries=[],
+             datas=[('ffmpeg/*/*', 'ffmpeg')],
+             hiddenimports=['pydub', 'huggingface_hub', 'dotenv'],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          exclude_binaries=True,
+          name='transcriber',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          console=True )
+coll = COLLECT(exe, a.binaries, a.zipfiles, a.datas,
+               strip=False,
+               upx=True,
+               name='transcriber')

--- a/build.py
+++ b/build.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+DIST = ROOT / 'dist'
+
+SPEC = ROOT / 'app.spec'
+
+
+def clean():
+    if DIST.exists():
+        shutil.rmtree(DIST)
+    build = ROOT / 'build'
+    if build.exists():
+        shutil.rmtree(build)
+
+
+def build_windows():
+    subprocess.check_call([
+        sys.executable, '-m', 'PyInstaller', str(SPEC)
+    ])
+
+
+def build_macos():
+    target = DIST / 'app'
+    target.mkdir(parents=True, exist_ok=True)
+    for f in ['main.py', 'gui.py', 'requirements.txt']:
+        shutil.copy(ROOT / f, target)
+    shutil.make_archive(str(DIST / 'transcriber-macos'), 'gztar', root_dir=target)
+
+
+def main():
+    clean()
+    if sys.platform.startswith('win'):
+        build_windows()
+    else:
+        build_macos()
+
+if __name__ == '__main__':
+    main()

--- a/ffmpeg/linux/ffmpeg
+++ b/ffmpeg/linux/ffmpeg
@@ -1,0 +1,1 @@
+placeholder for ffmpeg binary

--- a/ffmpeg/mac/ffmpeg
+++ b/ffmpeg/mac/ffmpeg
@@ -1,0 +1,1 @@
+placeholder for ffmpeg binary

--- a/ffmpeg/windows/ffmpeg.exe
+++ b/ffmpeg/windows/ffmpeg.exe
@@ -1,0 +1,1 @@
+placeholder for ffmpeg binary

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,63 @@
+import os
+from dotenv import load_dotenv
+from PySide6 import QtWidgets
+from PySide6.QtCore import QLibraryInfo
+from main import transcribe
+
+
+def set_qt_plugin_path():
+    if 'QT_PLUGIN_PATH' in os.environ:
+        return
+    plugin_path = QLibraryInfo.path(QLibraryInfo.PluginsPath)
+    if os.path.isdir(plugin_path):
+        os.environ['QT_PLUGIN_PATH'] = plugin_path
+
+class TokenDialog(QtWidgets.QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle('Transcriber GUI')
+        self.layout = QtWidgets.QVBoxLayout(self)
+
+        self.token_edit = QtWidgets.QLineEdit()
+        self.token_edit.setPlaceholderText('HuggingFace Token')
+        self.model_edit = QtWidgets.QLineEdit('openai/whisper-small')
+        self.file_edit = QtWidgets.QLineEdit()
+        self.browse_btn = QtWidgets.QPushButton('Browse')
+        self.run_btn = QtWidgets.QPushButton('Run')
+        self.output = QtWidgets.QTextEdit()
+
+        self.layout.addWidget(self.token_edit)
+        self.layout.addWidget(self.model_edit)
+        file_layout = QtWidgets.QHBoxLayout()
+        file_layout.addWidget(self.file_edit)
+        file_layout.addWidget(self.browse_btn)
+        self.layout.addLayout(file_layout)
+        self.layout.addWidget(self.run_btn)
+        self.layout.addWidget(self.output)
+
+        self.browse_btn.clicked.connect(self.select_file)
+        self.run_btn.clicked.connect(self.run)
+
+    def select_file(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, 'Select Audio')
+        if path:
+            self.file_edit.setText(path)
+
+    def run(self):
+        token = self.token_edit.text().strip()
+        if token:
+            os.environ['HF_TOKEN'] = token
+        load_dotenv()
+        result = transcribe(self.file_edit.text(), self.model_edit.text())
+        self.output.setPlainText(result)
+
+
+def main():
+    set_qt_plugin_path()
+    app = QtWidgets.QApplication([])
+    dlg = TokenDialog()
+    dlg.show()
+    app.exec()
+
+if __name__ == '__main__':
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,50 @@
+import argparse
+import os
+import sys
+from dotenv import load_dotenv
+from huggingface_hub import InferenceClient
+from pydub import AudioSegment
+
+# Prioritize bundled ffmpeg
+
+def get_ffmpeg_path() -> str:
+    base = os.path.join(os.path.dirname(__file__), 'ffmpeg')
+    if sys.platform.startswith('win'):
+        return os.path.join(base, 'windows', 'ffmpeg.exe')
+    elif sys.platform == 'darwin':
+        return os.path.join(base, 'mac', 'ffmpeg')
+    else:
+        return os.path.join(base, 'linux', 'ffmpeg')
+
+FFMPEG_BINARY = get_ffmpeg_path()
+if os.path.exists(FFMPEG_BINARY):
+    path_dir = os.path.dirname(FFMPEG_BINARY)
+    os.environ['PATH'] = os.pathsep.join([path_dir, os.environ.get('PATH', '')])
+    if sys.platform.startswith('win'):
+        os.environ['FFMPEG_BINARY'] = FFMPEG_BINARY
+
+load_dotenv()
+
+def transcribe(path: str, model: str, use_gpu: bool = False):
+    token = os.getenv('HF_TOKEN')
+    if not token:
+        raise ValueError('HF_TOKEN not provided')
+    client = InferenceClient(model, token=token)
+    audio = AudioSegment.from_file(path)
+    # Convert to wav bytes
+    wav_io = audio.export(format='wav')
+    wav_bytes = wav_io.read()
+    return client.audio_to_text(wav_bytes)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Simple CLI for speech recognition')
+    parser.add_argument('file', help='audio file path')
+    parser.add_argument('--model', default='openai/whisper-small', help='model name')
+    parser.add_argument('--use-gpu', action='store_true', help='enable GPU if available')
+    args = parser.parse_args(argv)
+    text = transcribe(args.file, args.model, args.use_gpu)
+    print(text)
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pyannote.audio
+huggingface_hub
+python-dotenv
+pydub
+PySide6


### PR DESCRIPTION
## Summary
- implement CLI/GUI transcriber example
- add bundled ffmpeg placeholders and cross‑platform path logic
- add PyInstaller spec and build helper
- set up GitHub Actions workflow
- provide README with setup and usage

## Testing
- `python -m py_compile main.py gui.py build.py`

------
https://chatgpt.com/codex/tasks/task_e_6849631a471c83338d7784d4e80917a2